### PR TITLE
Downgrade s3 plugin version to v0.8.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && gem install fluent-plugin-kubernetes_metadata_filter -v 1.0.1 \
     && gem install ffi -v 1.9.23 \
     && gem install fluent-plugin-systemd -v 0.0.9 \
-    && gem install fluent-plugin-s3 -v 1.1.4 \
+    && gem install fluent-plugin-s3 -v 0.8.7 \
     && SUDO_FORCE_REMOVE=yes \
     apt-get purge -y --auto-remove \
                   -o APT::AutoRemove::RecommendsImportant=false \


### PR DESCRIPTION
fluent-plugin-s3 v1.1.4 requires fluentd v1.2.5, which is not what we are currently using. When starting the container, we'll encounter the following error:

```
/usr/lib/ruby/2.3.0/rubygems/specification.rb:2290:in `raise_if_conflicts': Unable to activate fluent-plugin-systemd-0.0.9, because fluentd-1.2.5 conflicts with fluentd (~> 0.12) (Gem::ConflictError)
        from /usr/lib/ruby/2.3.0/rubygems/specification.rb:1411:in `activate'
        from /usr/lib/ruby/2.3.0/rubygems.rb:196:in `rescue in try_activate'
        from /usr/lib/ruby/2.3.0/rubygems.rb:193:in `try_activate'
...
```

This PR downgrades version of fluent-plugin-s3 to v0.8.7, which requires fluentd v0.10.58.